### PR TITLE
Fix versioneer compat with py311

### DIFF
--- a/examples/motor.py
+++ b/examples/motor.py
@@ -17,7 +17,7 @@ metadata = dict(rec.field_metadata())
 print('description field type', metadata['description'].type)
 print('derivative gain metadata', metadata['derivative_gain'])
 
-print('description metadata', rec.description.metadata)
+print('description metadata', rec.description.dbd_metadata)
 
 print('in links', list(rec.attrs_of_type('DBF_INLINK')))
 print('all links', list(rec.attrs_of_type(['DBF_INLINK', 'DBF_OUTLINK',

--- a/recordwhat/graph.py
+++ b/recordwhat/graph.py
@@ -137,7 +137,7 @@ def find_record_links(*starting_records):
                 continue
 
             try:
-                type_ = getattr(rec1, attr1).metadata.type
+                type_ = getattr(rec1, attr1).dbd_metadata.type
             except AttributeError:
                 type_ = 'unknown'
 

--- a/recordwhat/record_base.py
+++ b/recordwhat/record_base.py
@@ -29,7 +29,7 @@ class FieldComponent(Component):
             else:
                 FieldComponent._cls_metadata[record_cls] = metadata
 
-        cpt_inst.metadata = metadata.get(self.attr, None)
+        cpt_inst.dbd_metadata = metadata.get(self.attr, None)
         return cpt_inst
 
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -46,7 +46,7 @@ def smoke_test_motor(motor_rec):
     print('description field type', metadata['description'].type)
     print('derivative gain metadata', metadata['derivative_gain'])
 
-    print('description metadata', rec.description.metadata)
+    print('description metadata', rec.description.dbd_metadata)
 
     print('in links', list(rec.attrs_of_type('DBF_INLINK')))
     print('all links', list(rec.attrs_of_type(['DBF_INLINK', 'DBF_OUTLINK',
@@ -62,7 +62,7 @@ def test_records(rtyp, record):
     metadata = dict(rec.field_metadata())
     print('metadata', metadata)
 
-    print('description metadata', rec.description.metadata)
+    print('description metadata', rec.description.dbd_metadata)
 
     print('in links', list(rec.attrs_of_type('DBF_INLINK')))
     print('all links', list(rec.attrs_of_type(['DBF_INLINK', 'DBF_OUTLINK',

--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,8 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
-    with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+    parser = configparser.ConfigParser()
+    parser.read(setup_cfg)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
SafeConfigParser has been deprecated since Python 3.2 and will
be removed in py311.

https://github.com/python/cpython/pull/28292
https://bugs.python.org/issue45173